### PR TITLE
feat: First version

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -1,0 +1,16 @@
+settings:
+  jira_project_key: "TAP"
+  status_mapping:
+    opened: Untriaged
+    closed: done
+    not_planned: rejected
+    
+  components:
+    - parca
+      
+  add_gh_comment: false
+  sync_description: false
+  sync_comments: false
+
+  label_mapping:
+    "Type: Enhancement": Story

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug Report
+description: File a bug report
+labels: ["Type: Bug", "Status: Triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to fill out this bug report! Before submitting your issue, please make
+        sure you are using the latest version of the charm. If not, please try upgrading to the latest edge release prior to 
+        posting your report to make sure it's not already solved.
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug Description
+      description: >
+        If applicable, add screenshots to 
+        help explain the problem you are facing.      
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: To Reproduce
+      description: >
+        Please provide the output of `juju export-bundle` and step-by-step instructions for how to reproduce the behavior.
+        A deployment diagram could be handy too. See https://discourse.charmhub.io/t/9269 for examples.
+      placeholder: |
+        1. `juju deploy ...`
+        2. `juju relate ...`
+        3. `juju status --relations`
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: >
+        We need to know a bit more about the context in which you run the charm.
+        - Are you running Juju locally, on lxd, in multipass or on some other platform?
+        - What track and channel you deployed the charm from (ie. `latest/edge` or similar).
+        - Version of any applicable components, like the juju snap, the model controller, lxd, microk8s, and/or multipass.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: >
+        Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+        Fetch the logs using `juju debug-log --replay` and `kubectl logs ...`. Additional details available in the juju docs 
+        at https://juju.is/docs/olm/juju-logs
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Issue
+<!-- What issue is this PR trying to solve? -->
+
+
+## Solution
+<!-- A summary of the solution addressing the above issue -->
+
+
+## Context
+<!-- What is some specialized knowledge relevant to this project/technology -->
+
+
+## Testing Instructions
+<!-- What steps need to be taken to test this PR? -->
+
+
+## Upgrade Notes
+<!-- To upgrade from an older revision of charmed prometheus, ... -->

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,16 @@
+name: Pull Requests
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  pull-request:
+    name: PR
+    uses: canonical/observability/.github/workflows/rock-pull-request.yaml@v0
+    secrets: inherit

--- a/.github/workflows/rock-release-dev.yaml
+++ b/.github/workflows/rock-release-dev.yaml
@@ -1,0 +1,18 @@
+name: "Publish rock to GHCR:dev"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: canonical/observability/.github/workflows/rock-release-dev.yaml@v0
+    secrets: inherit
+    with:
+      rock-name: parca

--- a/.github/workflows/rock-release-oci-factory.yaml
+++ b/.github/workflows/rock-release-oci-factory.yaml
@@ -1,0 +1,14 @@
+name: Open a PR to OCI Factory
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: canonical/observability/.github/workflows/rock-release-oci-factory.yaml@v0
+    secrets: inherit
+    with:
+      rock-name: parca

--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -1,0 +1,15 @@
+name: Update rock
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  build:
+    uses: canonical/observability/.github/workflows/rock-update.yaml@v0
+    with:
+      rock-name: parca
+      source-repo: parca-dev/parca
+      check-go: true
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.rock
+.idea

--- a/0.22.0/parca.yaml
+++ b/0.22.0/parca.yaml
@@ -1,0 +1,6 @@
+object_storage:
+  bucket:
+    type: "FILESYSTEM"
+    config:
+      directory: "/var/lib/parca"
+scrape_configs: []

--- a/0.22.0/rockcraft.yaml
+++ b/0.22.0/rockcraft.yaml
@@ -6,7 +6,7 @@ base: ubuntu@24.04
 license: Apache-2.0
 services:
   parca:
-    command: /bin/parca --config-path=/etc/parca/parca.yaml
+    command: /parca --config-path=/etc/parca/parca.yaml
     override: replace
     startup: enabled
 platforms:
@@ -32,9 +32,9 @@ parts:
       npm install -g pnpm@9.15.4
       make ui/build
       make go/deps
-      go build -gcflags="all=-N -l" -ldflags "-X main.Version=${CRAFT_PROJECT_VERSION}" -o $CRAFT_PART_INSTALL/bin/ ./cmd/parca
+      go build -gcflags="all=-N -l" -ldflags "-X main.Version=${CRAFT_PROJECT_VERSION}" -o $CRAFT_PART_INSTALL/ ./cmd/parca
     stage:
-      - bin/parca
+      - parca
   default-config:
     plugin: dump
     source: .

--- a/0.22.0/rockcraft.yaml
+++ b/0.22.0/rockcraft.yaml
@@ -1,0 +1,58 @@
+name: parca
+summary: Parca in a rock.
+description: "Parca continuous profiling tool."
+version: "0.22.0"
+base: ubuntu@24.04
+license: Apache-2.0
+services:
+  parca:
+    command: /bin/parca --config-path=/etc/parca/parca.yaml
+    override: replace
+    startup: enabled
+platforms:
+  amd64:
+parts:
+  parca:
+    plugin: go
+    source: https://github.com/parca-dev/parca
+    source-type: git
+    source-tag: "v0.22.0"
+    source-depth: 1
+    build-snaps:
+      - go/1.23/stable
+      - node/18/stable
+    build-environment:
+      - BUILD_IN_CONTAINER: "false"
+      - NODE_OPTIONS: "--max-old-space-size=8192"
+    build-packages:
+      - libsystemd-dev
+      - jq
+    # pnpm is locked to 8.15.9 as latest fails with `ERR_PNPM_LOCKFILE_BREAKING_CHANGE Lockfile /root/parts/parca/build/ui/pnpm-lock.yaml not compatible with current pnpm`
+    override-build: |
+      npm install -g pnpm@8.15.9
+      npm install -g lerna@8.1.9
+      npm install -g typescript@5.0.4
+      cd ui && pnpm install --frozen-lockfile
+      pnpm run build
+      cd .. && make go/bin
+    stage:
+      - bin/parca
+  default-config:
+    plugin: dump
+    source: .
+    organize:
+      parca.yaml: etc/parca/parca.yaml
+    stage:
+      - etc/parca/parca.yaml
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
+  deb-security-manifest:
+    plugin: nil
+    after:
+      - parca
+      - ca-certs
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query

--- a/0.22.0/rockcraft.yaml
+++ b/0.22.0/rockcraft.yaml
@@ -20,21 +20,19 @@ parts:
     source-depth: 1
     build-snaps:
       - go/1.23/stable
-      - node/18/stable
     build-environment:
       - BUILD_IN_CONTAINER: "false"
       - NODE_OPTIONS: "--max-old-space-size=8192"
     build-packages:
       - libsystemd-dev
       - jq
-    # pnpm is locked to 8.15.9 as latest fails with `ERR_PNPM_LOCKFILE_BREAKING_CHANGE Lockfile /root/parts/parca/build/ui/pnpm-lock.yaml not compatible with current pnpm`
+      - nodejs
+      - npm
     override-build: |
-      npm install -g pnpm@8.15.9
-      npm install -g lerna@8.1.9
-      npm install -g typescript@5.0.4
-      cd ui && pnpm install --frozen-lockfile
-      pnpm run build
-      cd .. && make go/bin
+      npm install -g pnpm@9.15.4
+      make ui/build
+      make go/deps
+      go build -gcflags="all=-N -l" -ldflags "-X main.Version=${CRAFT_PROJECT_VERSION}" -o $CRAFT_PART_INSTALL/bin/ ./cmd/parca
     stage:
       - bin/parca
   default-config:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/Observability

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # parca-rock
+
+[![Open a PR to OCI Factory](https://github.com/canonical/parca-rock/actions/workflows/rock-release-oci-factory.yaml/badge.svg)](https://github.com/canonical/parca-rock/actions/workflows/rock-release-oci-factory.yaml)
+[![Publish to GHCR:dev](https://github.com/canonical/parca-rock/actions/workflows/rock-release-dev.yaml/badge.svg)](https://github.com/canonical/parca-rock/actions/workflows/rock-release-dev.yaml)
+[![Update Rock](https://github.com/canonical/parca-rock/actions/workflows/rock-update.yaml/badge.svg)](https://github.com/canonical/parca-rock/actions/workflows/rock-update.yaml)
+
+[Rocks](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/) for [Parca](https://www.parca.dev/).  
+This repository holds all the necessary files to build rocks for the upstream versions we support. The Parca rock is used by the [parca-k8s-operator](https://github.com/canonical/parca-k8s-operator) charm.
+
+The rocks on this repository are built with [OCI Factory](https://github.com/canonical/oci-factory/), which also takes care of periodically rebuilding the images.
+
+**How do I interact with this repo?** This repo uses [`just`](https://github.com/casey/just) to easily run some commands:
+```
+∮ just
+Available recipes:
+    clean version               # `rockcraft clean` for a specific version
+    pack version                # Pack a rock of a specific version
+    run version=latest_version  # Run a rock and open a shell into it with `kgoss`
+    test version=latest_version # Test the rock with `kgoss`
+```
+
+Automation takes care of:
+* validating PRs, by simply trying to build the rock;
+* pulling upstream releases, creating a PR with the necessary files to be manually reviewed;
+* on PRs, validate the added (or modified) rocks by running `kgoss`;
+* releasing to GHCR at [ghcr.io/canonical/parca:dev](https://ghcr.io/canonical/parca:dev), when merging to main, for development purposes.
+

--- a/goss.yaml
+++ b/goss.yaml
@@ -1,0 +1,10 @@
+process:
+  parca:
+    running: true
+http:
+  ready:
+    status: 200
+    url: http://localhost:7070/ready
+  metrics:
+    status: 200
+    url: http://localhost:7070/metrics

--- a/justfile
+++ b/justfile
@@ -1,0 +1,33 @@
+# set quiet # Recipes are silent by default
+set export # Just variables are exported to environment variables
+
+rock_name := `echo ${PWD##*/} | sed 's/-rock//'`
+latest_version := `find . -maxdepth 1 -type d | sort -V | tail -n1 | sed 's@./@@'`
+
+[private]
+default:
+  just --list
+
+# Push an OCI image to a local registry
+[private]
+push-to-registry version:
+  echo "Pushing $rock_name $version to local registry"
+  rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
+    "oci-archive:${version}/${rock_name}_${version}_amd64.rock" \
+    "docker://localhost:32000/${rock_name}-dev:${version}"
+
+# Pack a rock of a specific version
+pack version:
+  cd "$version" && rockcraft pack --debug --verbosity debug
+
+# `rockcraft clean` for a specific version
+clean version:
+  cd "$version" && rockcraft clean
+
+# Run a rock and open a shell into it with `kgoss`
+run version=latest_version: (push-to-registry version)
+  kgoss edit -i localhost:32000/${rock_name}-dev:${version}
+
+# Test the rock with `kgoss`
+test version=latest_version: (push-to-registry version)
+  GOSS_OPTS="--retry-timeout 60s" kgoss run -i localhost:32000/${rock_name}-dev:${version}

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ push-to-registry version:
 
 # Pack a rock of a specific version
 pack version:
-  cd "$version" && rockcraft pack --debug --verbosity debug
+  cd "$version" && rockcraft pack
 
 # `rockcraft clean` for a specific version
 clean version:


### PR DESCRIPTION
Wrapper for parca v0.22.0. It follows the same convention as the upstream docker image, placing the main binary under `/parca`.

# Context

We couldn't use the snapped version of node as it was failing with permission errors on `pnpm run build`. We've opted for the apt version of node instead as this is what's recommended for errors like this in most nodejs snap issues: https://github.com/nodejs/snap/issues 