### PR TITLE
chore: update to observability workflows v2 and refresh rocks.just

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,5 +12,5 @@ concurrency:
 jobs:
   pull-request:
     name: Pull Requests
-    uses: canonical/observability/.github/workflows/rock-pull-request.yaml@224c92a71bb24f4c67969c331c29b46876178a81
+    uses: canonical/observability/.github/workflows/rock-pull-request.yaml@v2
     secrets: inherit

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -13,5 +13,5 @@ concurrency:
 jobs:
   release-dev:
     name: Release to GHCR
-    uses: canonical/observability/.github/workflows/rock-release-dev.yaml@224c92a71bb24f4c67969c331c29b46876178a81
+    uses: canonical/observability/.github/workflows/rock-release-dev.yaml@v2
     secrets: inherit

--- a/.github/workflows/release-oci-factory.yaml
+++ b/.github/workflows/release-oci-factory.yaml
@@ -9,5 +9,5 @@ on:
 jobs:
   release-oci-factory:
     name: Release to OCI Factory
-    uses: canonical/observability/.github/workflows/rock-release-oci-factory.yaml@224c92a71bb24f4c67969c331c29b46876178a81
+    uses: canonical/observability/.github/workflows/rock-release-oci-factory.yaml@v2
     secrets: inherit

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   update:
     name: Update rock
-    uses: canonical/observability/.github/workflows/rock-update.yaml@224c92a71bb24f4c67969c331c29b46876178a81
+    uses: canonical/observability/.github/workflows/rock-update.yaml@v2
     secrets: inherit
     with:
       source-repo: parca-dev/parca

--- a/rocks.just
+++ b/rocks.just
@@ -4,6 +4,11 @@ set shell := ["bash", "-uc"]
 rock_name := `echo ${PWD##*/} | sed 's/-rock$//'`  # Get the rock name from the folder name
 latest_version := `find . -name rockcraft.yaml -printf '%h\n' | sort -V | tail -n1 | sed 's@./@@'`
 
+# LTS end-of-life overrides. Override this variable in the local 'justfile'.
+# Define mappings from LTS minor versions to their EOL date in YYYY-MM-DD format.
+# Example: lts_releases := '{"2.14": "2026-12-31", "2.12": "2025-06-30"}'
+lts_releases := '{}'
+
 [private]
 @default:
   just --list
@@ -61,15 +66,47 @@ test version=latest_version:
 [group("security")]
 sbom version=latest_version:
   syft {{version}}/*.rock -o "spdx-json={{version}}/rock.sbom.json"
+  @echo "✓ SBOM saved to {{version}}/rock.sbom.json"
+
+# Perform a securiy scan
+[group("security")]
+scan version=latest_version: (sbom version)
+  uvx --from=trivy-py trivy sbom "{{version}}/rock.sbom.json"
+  @echo "✓ Vulnerability scan done"
+
+# Check whether CVEs affect the upstream project
+[group("security")]
+govulncheck source_repo version=latest_version:
+  #!/usr/bin/env bash
+  set -e
+  echo "Cloning {{source_repo}}"
+  which -s govulncheck || { echo "govulncheck not found; install it with:  go install golang.org/x/vuln/cmd/govulncheck@latest"; exit 1; }
+  TMP_DIR="$(mktemp -d)"
+  gh repo clone "{{source_repo}}" "$TMP_DIR/{{source_repo}}" -- --branch "{{version}}" --depth 1 2>/dev/null \
+    || gh repo clone "{{source_repo}}" "$TMP_DIR/{{source_repo}}" -- --branch "v{{version}}" --depth 1
+  if [[ ! -f "$TMP_DIR/{{source_repo}}/go.mod" ]]; then
+    echo "⨯ {{source_repo}} is not a Go project (go.mod is missing)"
+    exit 2
+  fi
+  echo "Running 'govulncheck' (this may take a while)"
+  vuln_exit=0; (cd "$TMP_DIR/{{source_repo}}" && govulncheck ./...) || vuln_exit=$?
+  rm -rf "$TMP_DIR"
+  if [ "$vuln_exit" -ne 0 ]; then echo "⨯ 'govulncheck' failed"; exit "$vuln_exit"; fi
+  echo "✓ 'govulncheck' passed."
 
 # Generate a rock for the latest version of the upstream project
 [arg("source_repo", help="Repository of the upstream project in 'org/repo' form")]
 [group("maintenance")]
-update source_repo:
+update source_repo release_tag="":
   #!/usr/bin/env bash
   set -e
-  latest_release="$(gh release list --repo {{source_repo}} --exclude-pre-releases --limit=1 --json tagName --jq '.[0].tagName')"
-  echo "Latest release for {{source_repo}} is $latest_release"
+  if [[ -z "{{release_tag}}" ]]; then
+    latest_release="$(gh release list --repo {{source_repo}} --exclude-pre-releases --limit=1 --json tagName --jq '.[0].tagName')"
+    echo "Latest release for {{source_repo}} is $latest_release"
+  else
+    latest_release="{{release_tag}}"
+    echo "Release version manually set to $latest_release"
+  fi
   # Explicitly filter out prefixes for known rocks, so we can notice if a new rock has a different schema
   version="${latest_release}"
   version="${version#mimir-}"  # mimir
@@ -99,6 +136,7 @@ update source_repo:
 [group("maintenance")]
 refresh:
   #!/usr/bin/env bash
+  which -s gh || { echo "gh not found"; exit 1; }
   refresh_folder="blueprints/rocks"
   api_path="repos/canonical/observability/contents/$refresh_folder"
   for file in rocks.just spread.yaml; do
@@ -130,22 +168,42 @@ release-oci-factory version=latest_version support="minor" risk="stable":
   if [[ -z "$GITHUB_TOKEN" ]]; then echo "× Please export GITHUB_TOKEN for the user observability-noctua-bot"; exit 1; fi
   if [ ! -e {{version}}/*.rock ]; then echo "× Error: rock not found. Please run 'just pack {{version}}' first."; exit 2; fi
   repository="$(git remote get-url origin | sed -E 's#(git@[^:]+:|https?://[^/]+/)##; s/\.git$//')"
+  # Extract the base from the rockcraft.yaml (e.g. "ubuntu@24.04" -> "24.04")
+  rock_base="$(yq -r '.base' "{{version}}/rockcraft.yaml" | sed 's/.*@//')"
+  echo "Detected base: $rock_base"
   # Clone the oci-factory and push data to it
   gh repo sync --force observability-noctua-bot/oci-factory
   TMP_DIR="$(mktemp -d)"
   git clone https://github.com/observability-noctua-bot/oci-factory "$TMP_DIR/oci-factory"
   echo "✓ Cloned observability-noctua-bot/oci-factory"
   # Build the OCI Factory manifest
+  # Check if this version has a custom EOL in lts_releases
+  minor_version="$(echo "{{version}}" | grep -oP '^\d+\.\d+')"
+  eol_date="$(echo '{{lts_releases}}' | jq -r --arg v "$minor_version" '.[$v] // empty')"
+  eol_flag=""
+  if [[ -n "$eol_date" ]]; then
+    eol_flag="--eol=$eol_date"
+    echo "LTS release detected: EOL set to $eol_date"
+  fi
   echo "Building the OCI Factory manifest..."; echo
+  manifest_file="$TMP_DIR/oci-factory/oci/{{rock_name}}/image.yaml"
   uvx --from=git+https://github.com/lucabello/noctua noctua rock manifest \
     "$repository" \
     --commit="$(git rev-parse HEAD)" \
-    --base=24.04 \
+    --base="$rock_base" \
     --support="{{support}}" \
     --risk="{{risk}}" \
     --version="{{version}}" \
-    | tee "$TMP_DIR/oci-factory/oci/{{rock_name}}/image.yaml"
+    $eol_flag \
+    | tee "$manifest_file"
   echo; echo "✓ OCI Factory manifest generated"
+  # If there's nothing to upload, exit early
+  upload_count="$(cat "$manifest_file" | yq '.upload | length')"
+  if [[ "$upload_count" -eq 0 ]]; then
+    echo "✓ Nothing to update in OCI Factory"
+    rm -rf "$TMP_DIR"
+    exit 0
+  fi
   # Commit the changes and create a PR
   pushd "$TMP_DIR/oci-factory" >/dev/null
   git config user.name observability-noctua-bot


### PR DESCRIPTION
Pin reusable workflows to `@v2` tag and refresh `rocks.just` / `spread.yaml` from canonical/observability blueprints.